### PR TITLE
Changed Gradle Version in RosAndroid.groovy

### DIFF
--- a/gradle_plugins/src/main/groovy/org/ros/gradle_plugins/RosAndroid.groovy
+++ b/gradle_plugins/src/main/groovy/org/ros/gradle_plugins/RosAndroid.groovy
@@ -26,7 +26,7 @@ class RosAndroidPlugin implements Plugin<Project> {
                 mavenCentral()
             }
             dependencies {
-                classpath 'com.android.tools.build:gradle:0.11.+'
+                classpath 'com.android.tools.build:gradle:1.12.+'
             }
         }
         /********************************************************************** 


### PR DESCRIPTION
Changed Gradle Version in RosAndroid.groovy to allow for building in Android Studio 0.6.1
