### PR TITLE
Update Android Build Tools

### DIFF
--- a/gradle_plugins/src/main/groovy/org/ros/gradle_plugins/RosAndroid.groovy
+++ b/gradle_plugins/src/main/groovy/org/ros/gradle_plugins/RosAndroid.groovy
@@ -11,7 +11,7 @@ class RosAndroidPlugin implements Plugin<Project> {
   void apply(Project project) {
     project.apply plugin: "ros"
     project.extensions.create("rosandroid", RosAndroidPluginExtension)
-    project.rosandroid.buildToolsVersion = "21.1.2"
+    project.rosandroid.buildToolsVersion = "25.0.2"
 
     /********************************************************************** 
      * Publishing - not we're using old style here. Upgrade to maven-publish


### PR DESCRIPTION
The previously used version [has trouble running on current 64 bit distros](http://stackoverflow.com/questions/22701405/aapt-ioexception-error-2-no-such-file-or-directory-why-cant-i-build-my-grad)