### PR TITLE
Switch to publish target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ project(rosjava_bootstrap)
 
 find_package(catkin REQUIRED rosjava_build_tools)
 
-catkin_rosjava_setup(publishMavenJavaPublicationToMavenRepository installApp)
+catkin_rosjava_setup(publish installApp)
 
 catkin_package()
 

--- a/build.gradle
+++ b/build.gradle
@@ -63,4 +63,4 @@ subprojects {
   }
 }
 
-defaultTasks 'publishMavenJavaPublicationToMavenRepository', 'installApp'
+defaultTasks 'publish', 'installApp'


### PR DESCRIPTION
Use the less-difficult-to-pronounce `publish` Gradle target for libraries.

Starting with this particular package first to confirm it doesn't break deb publishing. Afterwards we can update `rosjava_build_tools` accordingly. 