### PR TITLE
Fixes serialization of non-initialized ChannelBufferField

### DIFF
--- a/message_generation/src/main/java/org/ros/internal/message/field/ChannelBufferField.java
+++ b/message_generation/src/main/java/org/ros/internal/message/field/ChannelBufferField.java
@@ -64,7 +64,7 @@ public class ChannelBufferField extends Field {
     }
     // By specifying the start index and length we avoid modifying value's
     // indices and marks.
-    buffer.writeBytes(value, 0, value.readableBytes());
+    buffer.writeBytes(value, 0, Math.max(value.readableBytes(), size));
   }
 
   @Override


### PR DESCRIPTION
uninitialized fixed-length uint8 array messages (which are compiled into ChannelBufferField objects) were being serielized as a 0-length array, causing very obscure problems.

This was detected when trying to use [uuid_msgs/UniqueID](http://docs.ros.org/jade/api/uuid_msgs/html/msg/UniqueID.html) as part of another message. The resulting symptom was that no message was being published.

@ernestmc could you please review this fix and test with the failing project when you get a chance?