### PR TITLE
Fix for message_generation dependency

### DIFF
--- a/gradle_plugins/src/main/groovy/org/ros/gradle_plugins/CatkinPlugin.groovy
+++ b/gradle_plugins/src/main/groovy/org/ros/gradle_plugins/CatkinPlugin.groovy
@@ -130,7 +130,7 @@ class CatkinPackages {
     def pkg = this.pkgs[package_name]
     project.version = pkg.version
     /* println("Artifact: " + pkg.name + "-" + pkg.version) */
-    project.dependencies.add("compile", 'org.ros.rosjava_bootstrap:message_generation:[0.2,0.3)')
+    project.dependencies.add("compile", 'org.ros.rosjava_bootstrap:message_generation:[0.3,0.4)')
     Set<String> messageDependencies = pkg.getMessageDependencies()
     messageDependencies.each { d ->
       if ( project.getParent().getChildProjects().containsKey(d) ) {


### PR DESCRIPTION
This fix bumps message_generation version to kinetic range in CatkinPlugin script to generate new custom message artifacts properly.

See https://github.com/rosjava/rosjava_mvn_repo/issues/27 and https://github.com/rosjava/rosjava_mvn_repo/issues/32.