### PR TITLE
fixed message generation for local build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bin
 *.iml
 .idea
 local.properties
+/.nb-gradle/

--- a/buildscript.gradle
+++ b/buildscript.gradle
@@ -38,9 +38,6 @@ rootProject.buildscript {
                 url rosMavenRepository
             }
         }
-        maven {
-            url "https://github.com/rosjava/rosjava_mvn_repo/raw/master"
-        }
         jcenter()
     }
     dependencies {

--- a/gradle_plugins/src/main/groovy/org/ros/gradle_plugins/CatkinPlugin.groovy
+++ b/gradle_plugins/src/main/groovy/org/ros/gradle_plugins/CatkinPlugin.groovy
@@ -58,17 +58,21 @@ class CatkinPlugin implements Plugin<Project> {
         }
 	    setTasks()
     }
-    def void setTasks() {
-        project.task('catkinPackageInfo') << {
-            println("CatkinPlugin is happy, you should be too.")
-            println("Catkin Workspaces........." + project.catkin.workspaces)
-            println("Catkin Packages")
-            project.catkin.packages.each { pkg ->
-                print pkg.value.toString()
-            }
-        }
-    }
+
+  def void setTasks() {
+      project.task('catkinPackageInfo') << {
+          println("CatkinPlugin is happy, you should be too.")
+          println("Catkin Workspaces........." + project.catkin.workspaces)
+          println("Catkin Packages")
+          project.catkin.packages.each { pkg ->
+              print pkg.value.toString()
+          }
+      }
+  }
+  
 }
+
+
 class CatkinPluginExtension {
   CatkinPackage pkg
   List<String> workspaces
@@ -90,8 +94,7 @@ class CatkinPackages {
   void generate() {
     if (pkgs.size() == 0) {
       workspaces.each { workspace ->
-        def manifestTree = project.fileTree(dir: workspace,
-                                            include: "**/package.xml")
+        def manifestTree = project.fileTree(dir: workspace, include: "**/package.xml")
         manifestTree.each { file -> 
           def pkg = new CatkinPackage(project, file)
           if(this.pkgs.containsKey(pkg.name)) {
@@ -146,7 +149,7 @@ class CatkinPackages {
     generateSourcesTask.description = "Generate sources for " + pkg.name
     generateSourcesTask.outputs.dir(project.file(generatedSourcesDir))
     /* generateSourcesTask.args = new ArrayList<String>([generatedSourcesDir, pkg.name]) */
-    generateSourcesTask.args = new ArrayList<String>([generatedSourcesDir, '--package-path=' + pkg.directory, pkg.name])
+    generateSourcesTask.args = new ArrayList<String>(['--output-path', generatedSourcesDir, '--package-path', pkg.directory, '--package-names', pkg.name])
     generateSourcesTask.classpath = project.configurations.runtime
     generateSourcesTask.main = "org.ros.internal.message.GenerateInterfaces"
     project.tasks.compileJava.source generateSourcesTask.outputs.files

--- a/message_generation/build.gradle
+++ b/message_generation/build.gradle
@@ -34,6 +34,7 @@ dependencies {
   compile 'org.apache.commons:com.springsource.org.apache.commons.io:1.4.0'
   compile 'commons-pool:commons-pool:1.6'
   compile 'org.apache.commons:com.springsource.org.apache.commons.lang:2.4.0'
+  compile group: 'args4j', name: 'args4j', version: '2.0.16'
   compile project(':gradle_plugins')
   testCompile 'junit:junit:4.8.2'
 }

--- a/message_generation/src/main/java/org/ros/message/MessageIdentifier.java
+++ b/message_generation/src/main/java/org/ros/message/MessageIdentifier.java
@@ -74,6 +74,11 @@ public class MessageIdentifier {
     pkg = packageAndName[0];
     name = packageAndName[1];
   }
+  
+  
+  public void setPackage(String pkg) {
+      this.pkg = pkg;
+  }
 
   public String getPackage() {
     if (pkg == null) {


### PR DESCRIPTION
this fixes failing message generation in non catkin build folder.

Without this fix message_generation fails to generate message files if the given package folder is named differently than the pkg as the package of single files is guessed from the path which fails on non catkin workspaces which results in empty rosjava_message/pkg jars. 

This fix forces all files in the given package parameter into the given pkg_name if only one argument is given for package-path and pkg-name.