### PR TITLE
Test fixed size arrays

### DIFF
--- a/message_generation/src/test/java/org/ros/internal/message/RawMessageSerializationTest.java
+++ b/message_generation/src/test/java/org/ros/internal/message/RawMessageSerializationTest.java
@@ -300,4 +300,19 @@ public class RawMessageSerializationTest {
     RawMessage rawMessage = messageFactory.newFromType("foo/foo");
     checkSerializeAndDeserialize(rawMessage);
   }
+
+  @Test
+  public void testFloat64FixedSizeArrayWithInitialization() {
+    topicDefinitionResourceProvider.add("foo/foo", "float64[5] data");
+    RawMessage rawMessage = messageFactory.newFromType("foo/foo");
+    rawMessage.setFloat64Array("data", new double[] { 1, 2, 3, 4, 5 });
+    checkSerializeAndDeserialize(rawMessage);
+  }
+  
+  @Test
+  public void testFloat64FixedSizeArrayNoInitialization() {
+    topicDefinitionResourceProvider.add("foo/foo", "float64[5] data");
+    RawMessage rawMessage = messageFactory.newFromType("foo/foo");
+    checkSerializeAndDeserialize(rawMessage);
+  }
 }

--- a/message_generation/src/test/java/org/ros/internal/message/RawMessageSerializationTest.java
+++ b/message_generation/src/test/java/org/ros/internal/message/RawMessageSerializationTest.java
@@ -19,6 +19,7 @@ package org.ros.internal.message;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.Lists;
+import java.util.Arrays;
 
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.junit.Before;
@@ -278,6 +279,16 @@ public class RawMessageSerializationTest {
   }
 
   @Test
+  public void testChannelBufferFixedSizeWithIncompleteInitialization() {
+    topicDefinitionResourceProvider.add("foo/foo", "uint8[5] data");
+    ChannelBuffer buffer = MessageBuffers.dynamicBuffer();
+    buffer.writeBytes(new byte[] { 1, 2, 3 });
+    RawMessage rawMessage = messageFactory.newFromType("foo/foo");
+    rawMessage.setChannelBuffer("data", buffer);
+    checkSerializeAndDeserialize(rawMessage);
+  }
+
+  @Test
   public void testChannelBufferFixedSizeNoInitialization() {
     topicDefinitionResourceProvider.add("foo/foo", "uint8[5] data");
     ChannelBuffer buffer = MessageBuffers.dynamicBuffer();
@@ -295,6 +306,14 @@ public class RawMessageSerializationTest {
   }
   
   @Test
+  public void testInt32FixedSizeArrayWithIncompleteInitialization() {
+    topicDefinitionResourceProvider.add("foo/foo", "int32[5] data");
+    RawMessage rawMessage = messageFactory.newFromType("foo/foo");
+    rawMessage.setInt32Array("data", new int[] { 1, 2, 3 });
+    checkSerializeAndDeserialize(rawMessage);
+  }
+
+  @Test
   public void testInt32FixedSizeArrayNoInitialization() {
     topicDefinitionResourceProvider.add("foo/foo", "int32[5] data");
     RawMessage rawMessage = messageFactory.newFromType("foo/foo");
@@ -308,10 +327,43 @@ public class RawMessageSerializationTest {
     rawMessage.setFloat64Array("data", new double[] { 1, 2, 3, 4, 5 });
     checkSerializeAndDeserialize(rawMessage);
   }
+
+  @Test
+  public void testFloat64FixedSizeArrayWithIncompleteInitialization() {
+    topicDefinitionResourceProvider.add("foo/foo", "float64[5] data");
+    RawMessage rawMessage = messageFactory.newFromType("foo/foo");
+    rawMessage.setFloat64Array("data", new double[] { 1, 2, 3 });
+    checkSerializeAndDeserialize(rawMessage);
+  }
   
   @Test
   public void testFloat64FixedSizeArrayNoInitialization() {
     topicDefinitionResourceProvider.add("foo/foo", "float64[5] data");
+    RawMessage rawMessage = messageFactory.newFromType("foo/foo");
+    checkSerializeAndDeserialize(rawMessage);
+  }
+
+  @Test
+  public void testStringFixedSizeArrayWithInitialization() {
+    topicDefinitionResourceProvider.add("foo/foo", "string[5] data");
+    RawMessage rawMessage = messageFactory.newFromType("foo/foo");
+    String[] stringArray = new String[] { "String 1", "String 2", "String 3", "String 4", "String 5" };
+    rawMessage.setStringList("data", Arrays.asList(stringArray));
+    checkSerializeAndDeserialize(rawMessage);
+  }
+
+  @Test
+  public void testStringFixedSizeArrayWithIncompleteInitialization() {
+    topicDefinitionResourceProvider.add("foo/foo", "string[5] data");
+    RawMessage rawMessage = messageFactory.newFromType("foo/foo");
+    String[] stringArray = new String[] { "String 1", "String 2", "String 3" };
+    rawMessage.setStringList("data", Arrays.asList(stringArray));
+    checkSerializeAndDeserialize(rawMessage);
+  }
+
+  @Test
+  public void testStringFixedSizeArrayWithNoInitialization() {
+    topicDefinitionResourceProvider.add("foo/foo", "string[5] data");
     RawMessage rawMessage = messageFactory.newFromType("foo/foo");
     checkSerializeAndDeserialize(rawMessage);
   }

--- a/message_generation/src/test/java/org/ros/internal/message/RawMessageSerializationTest.java
+++ b/message_generation/src/test/java/org/ros/internal/message/RawMessageSerializationTest.java
@@ -266,4 +266,38 @@ public class RawMessageSerializationTest {
     rawMessage.setFloat64Array("data", new double[] { 1, 2, 3, 4, 5 });
     checkSerializeAndDeserialize(rawMessage);
   }
+  
+  @Test
+  public void testChannelBufferFixedSizeWithInitialization() {
+    topicDefinitionResourceProvider.add("foo/foo", "uint8[5] data");
+    ChannelBuffer buffer = MessageBuffers.dynamicBuffer();
+    buffer.writeBytes(new byte[] { 1, 2, 3, 4, 5 });
+    RawMessage rawMessage = messageFactory.newFromType("foo/foo");
+    rawMessage.setChannelBuffer("data", buffer);
+    checkSerializeAndDeserialize(rawMessage);
+  }
+
+  @Test
+  public void testChannelBufferFixedSizeNoInitialization() {
+    topicDefinitionResourceProvider.add("foo/foo", "uint8[5] data");
+    ChannelBuffer buffer = MessageBuffers.dynamicBuffer();
+    RawMessage rawMessage = messageFactory.newFromType("foo/foo");
+    rawMessage.setChannelBuffer("data", buffer);
+    checkSerializeAndDeserialize(rawMessage);
+  }
+  
+  @Test
+  public void testInt32FixedSizeArrayWithInitialization() {
+    topicDefinitionResourceProvider.add("foo/foo", "int32[5] data");
+    RawMessage rawMessage = messageFactory.newFromType("foo/foo");
+    rawMessage.setInt32Array("data", new int[] { 1, 2, 3, 4, 5 });
+    checkSerializeAndDeserialize(rawMessage);
+  }
+  
+  @Test
+  public void testInt32FixedSizeArrayNoInitialization() {
+    topicDefinitionResourceProvider.add("foo/foo", "int32[5] data");
+    RawMessage rawMessage = messageFactory.newFromType("foo/foo");
+    checkSerializeAndDeserialize(rawMessage);
+  }
 }

--- a/message_generation/src/test/java/org/ros/internal/message/RawMessageSerializationTest.java
+++ b/message_generation/src/test/java/org/ros/internal/message/RawMessageSerializationTest.java
@@ -367,4 +367,27 @@ public class RawMessageSerializationTest {
     RawMessage rawMessage = messageFactory.newFromType("foo/foo");
     checkSerializeAndDeserialize(rawMessage);
   }
+
+  @Test
+  public void testByteFixedSizeArrayWithInitialization() {
+    topicDefinitionResourceProvider.add("foo/foo", "byte[5] data");
+    RawMessage rawMessage = messageFactory.newFromType("foo/foo");
+    rawMessage.setInt8Array("data", new byte[] { 1, 2, 3, 4, 5 });
+    checkSerializeAndDeserialize(rawMessage);
+  }
+
+  @Test
+  public void testByteFixedSizeArrayWithIncompleteInitialization() {
+    topicDefinitionResourceProvider.add("foo/foo", "byte[5] data");
+    RawMessage rawMessage = messageFactory.newFromType("foo/foo");
+    rawMessage.setInt8Array("data", new byte[] { 1, 2, 3 });
+    checkSerializeAndDeserialize(rawMessage);
+  }
+
+  @Test
+  public void testByteFixedSizeArrayWithNoInitialization() {
+    topicDefinitionResourceProvider.add("foo/foo", "byte[5] data");
+    RawMessage rawMessage = messageFactory.newFromType("foo/foo");
+    checkSerializeAndDeserialize(rawMessage);
+  }
 }


### PR DESCRIPTION
Adds unit test cases for fixed sized arrays with different data types.
Note that currently some tests are not passing and will be addressed in future pull requests like https://github.com/rosjava/rosjava_bootstrap/pull/59 which is pending review.

To run the tests:
```
./gradlew test
```
Here's a snapshot of the current status of the tests:

![image](https://user-images.githubusercontent.com/9289769/38632146-2d29d1aa-3d92-11e8-880b-b2f51449cd74.png)
