### PR TITLE
renamed message action response to result

### DIFF
--- a/message_generation/src/main/java/org/ros/internal/message/GenerateInterfaces.java
+++ b/message_generation/src/main/java/org/ros/internal/message/GenerateInterfaces.java
@@ -156,7 +156,7 @@ public class GenerateInterfaces {
       MessageDeclaration goalDeclaration =
               MessageDeclaration.of(actionType.getType() + "Goal", goalResultAndFeedback.get(0));
       MessageDeclaration resultDeclaration =
-              MessageDeclaration.of(actionType.getType() + "Response", goalResultAndFeedback.get(1));
+              MessageDeclaration.of(actionType.getType() + "Result", goalResultAndFeedback.get(1));
       MessageDeclaration feedbackDeclaration =
               MessageDeclaration.of(actionType.getType() + "Feedback", goalResultAndFeedback.get(2));
 


### PR DESCRIPTION
I noticed that the generated name of the action result was named `<ACTION_NAME>Response` instead of `<ACTION_NAME>Result` as in `roscpp` and `rospy`.