### PR TITLE
Using ChannelBuffer for int8[] types

### DIFF
--- a/message_generation/src/main/java/org/ros/internal/message/MessageImpl.java
+++ b/message_generation/src/main/java/org/ros/internal/message/MessageImpl.java
@@ -161,8 +161,8 @@ class MessageImpl implements RawMessage, GetInstance {
   }
 
   @Override
-  public byte[] getInt8Array(String name) {
-    return (byte[]) messageFields.getFieldValue(name);
+  public ChannelBuffer getInt8Array(String name) {
+    return (ChannelBuffer) messageFields.getFieldValue(name);
   }
 
   @Override

--- a/message_generation/src/main/java/org/ros/internal/message/RawMessage.java
+++ b/message_generation/src/main/java/org/ros/internal/message/RawMessage.java
@@ -85,7 +85,7 @@ public interface RawMessage extends Message {
 
   byte getInt8(String name);
 
-  byte[] getInt8Array(String name);
+  ChannelBuffer getInt8Array(String name);
 
   <T extends Message> T getMessage(String name);
 

--- a/message_generation/src/main/java/org/ros/internal/message/field/ChannelBufferField.java
+++ b/message_generation/src/main/java/org/ros/internal/message/field/ChannelBufferField.java
@@ -19,6 +19,7 @@ package org.ros.internal.message.field;
 import com.google.common.base.Preconditions;
 
 import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.buffer.ChannelBuffers;
 import org.ros.internal.message.MessageBuffers;
 
 import java.nio.ByteOrder;
@@ -52,9 +53,15 @@ public class ChannelBufferField extends Field {
 
   @Override
   public void setValue(Object value) {
-    Preconditions.checkArgument(((ChannelBuffer) value).order() == ByteOrder.LITTLE_ENDIAN);
-    Preconditions.checkArgument(size < 0 || ((ChannelBuffer) value).readableBytes() == size);
-    this.value = (ChannelBuffer) value;
+    ChannelBuffer channelBufferValue = null;
+    if (value instanceof byte[]) {
+      channelBufferValue = ChannelBuffers.wrappedBuffer(ByteOrder.LITTLE_ENDIAN, byte[].class.cast(value));
+    } else if (value instanceof ChannelBuffer) {
+      channelBufferValue = ChannelBuffer.class.cast(value);
+    }
+    Preconditions.checkArgument(channelBufferValue.order() == ByteOrder.LITTLE_ENDIAN);
+    Preconditions.checkArgument(size < 0 || channelBufferValue.readableBytes() == size);
+    this.value = channelBufferValue;
   }
 
   @Override

--- a/message_generation/src/main/java/org/ros/internal/message/field/PrimitiveFieldType.java
+++ b/message_generation/src/main/java/org/ros/internal/message/field/PrimitiveFieldType.java
@@ -81,7 +81,7 @@ public enum PrimitiveFieldType implements FieldType {
 
     @Override
     public Field newVariableList(String name, int size) {
-      return ByteArrayField.newVariable(this, name, size);
+      return ChannelBufferField.newVariable(this, name, size);
     }
 
     @Override

--- a/message_generation/src/test/java/org/ros/internal/message/MessageTest.java
+++ b/message_generation/src/test/java/org/ros/internal/message/MessageTest.java
@@ -114,7 +114,6 @@ public class MessageTest {
     assertEquals("Hello, ROS! # comment", rawMessage.getString("data"));
   }
 
-  @Test
   public void testInt8List() {
     topicDefinitionResourceProvider.add("foo/foo", "int8[] data");
     RawMessage rawMessage = messageFactory.newFromType("foo/foo");

--- a/message_generation/src/test/java/org/ros/internal/message/MessageTest.java
+++ b/message_generation/src/test/java/org/ros/internal/message/MessageTest.java
@@ -20,10 +20,14 @@ import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.Lists;
 
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.buffer.ChannelBuffers;
 import org.junit.Before;
 import org.junit.Test;
 import org.ros.internal.message.topic.TopicDefinitionResourceProvider;
 import org.ros.message.MessageFactory;
+
+import java.nio.ByteOrder;
 
 /**
  * @author damonkohler@google.com (Damon Kohler)
@@ -114,11 +118,13 @@ public class MessageTest {
     assertEquals("Hello, ROS! # comment", rawMessage.getString("data"));
   }
 
+  @Test
   public void testInt8List() {
     topicDefinitionResourceProvider.add("foo/foo", "int8[] data");
     RawMessage rawMessage = messageFactory.newFromType("foo/foo");
-    byte[] data = new byte[] { (byte) 1, (byte) 2, (byte) 3 };
-    rawMessage.setInt8Array("data", data);
+    byte[] rawData = new byte[] { (byte) 1, (byte) 2, (byte) 3 };
+    ChannelBuffer data = ChannelBuffers.wrappedBuffer(ByteOrder.LITTLE_ENDIAN, rawData);
+    rawMessage.setInt8Array("data", rawData);
     assertEquals(data, rawMessage.getInt8Array("data"));
   }
 }


### PR DESCRIPTION
I noticed that the changes in #65, messages with `int8[]` fields are converted to `byte[]` datatypes in Java messages, but all the message artifacts in `rosjava_mvn_repo` and the code in `android_core` and so on is still using `ChannelBuffer` for these cases.

Steps to reproduce: build `rosjava` ws from source, source the environment, and build `android_core` from scratch using `catkin`. `catkin` will use the generated message artifacts in the first step instead of using the artifacts in `rosjava_mvn_repo`, and the build will break when trying to use `getData` from messages containing `byte[]`. Error copied below:

```
src/org/ros/android/view/visualization/layer/CompressedOccupancyGridLayer.java:94: error: incompatible types: byte[] cannot be converted to ChannelBuffer
    ChannelBuffer buffer = message.getData();
```

I'm not saying that using `byte[]` is wrong, but it breaks the API for messages using this type of objects and therefore all the code using these messages.

This PR reverts the changes in #65 and attempts to fix the test by using `ChannelBuffer` instead of `byte[]` in `RawMessage` interface. I'm not 100% sure whether we should support `byte[]` in the set method.

Comments on this are welcome.